### PR TITLE
Lefthookのpre-commitが正常に動くようにする

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PhpCsFixer' => true,
+        '@PHP80Migration:risky' => true,
+        'blank_line_after_opening_tag' => false,
+        'blank_line_before_statement' => false,
+        'linebreak_after_opening_tag' => false,
+        'multiline_whitespace_before_semicolons' => [
+            'strategy' => 'no_multi_line',
+        ],
+    ]);

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,12 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "php-cs-fixer": [
+            "./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+        ],
+        "phpstan": [
+            "./vendor/bin/phpstan analyse --memory-limit=1G"
         ]
     },
     "extra": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,5 +2,5 @@ pre-commit:
   parallel: true
   commands:
     php-cs-fixer:
-      files: git diff --name-only @{push}
-      run: ./vendor/bin/php-cs-fixer fix --dry-run {files}
+      glob: '*.php'
+      run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run -- {staged_files}


### PR DESCRIPTION
Resolves #10

- `lefthook.yml`の記述を修正
- PHP CS Fixerの設定ファイル `.php-cs-fixer.dist.php` を追加
- ついでにComposer scriptsによく使うコマンドを登録